### PR TITLE
Use solution file to determine .fsproj precedence

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
         "**/bin/": true,
         "**/obj/": true
     },
-    "fsharp.trace.server": "messages"
+    "fsharp.trace.server": "messages",
+    "files.trimTrailingWhitespace": false
 }

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+     <clear />
+  </disabledPackageSources>
+</configuration>

--- a/package.json
+++ b/package.json
@@ -75,11 +75,6 @@
                     ],
                     "default": "off",
                     "description": "Traces the communication between VSCode and the language server."
-                },
-                "fsharp.projects.include": {
-                    "scope": "window",
-                    "type": "array",
-                    "description": "If set, only these project files will be parsed."
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -75,6 +75,11 @@
                     ],
                     "default": "off",
                     "description": "Traces the communication between VSCode and the language server."
+                },
+                "fsharp.projects.include": {
+                    "scope": "window",
+                    "type": "array",
+                    "description": "If set, only these project files will be parsed."
                 }
             }
         },

--- a/src/FSharpLanguageServer/Program.fs
+++ b/src/FSharpLanguageServer/Program.fs
@@ -516,17 +516,6 @@ type Server(client: ILanguageClient) =
         let parts = name.Split('.') |> Array.toList
         tryReadInner parts settings
 
-    let tryGetProjectsInclude settings =
-        match tryReadSetting settings "fsharp.projects.include" with
-        | Some(JsonValue.Array values) ->
-            values
-            |> Array.choose (function
-                | JsonValue.String s -> Some s
-                | _ -> None)
-            |> Array.toList
-            |> Some
-        | _ -> None
-
     interface ILanguageServer with 
         member this.Initialize(p: InitializeParams) =
             async {
@@ -563,8 +552,6 @@ type Server(client: ILanguageClient) =
         member this.DidChangeConfiguration(p: DidChangeConfigurationParams): Async<unit> =
             async {
                 dprintfn "New configuration %s" (p.ToString())
-                tryGetProjectsInclude p.settings 
-                |> Option.iter projects.IncludeProjectFiles
             }
         member this.DidOpenTextDocument(p: DidOpenTextDocumentParams): Async<unit> = 
             async {


### PR DESCRIPTION
I just found this project and it looks really interesting. Great job! I gave it a try and it worked quite well but in Fable repo I had a problem because there're many F# projects there and sometimes they share some files. Because fsharp-language-server is not reading the solution file, it's picking sometimes the wrong project for a file and it shows too many errors.

I considered how to fix this problem and came up with this: adding a `fsharp.projects.include` option so in similar cases users can decide which projects they want to load. The feature is very simple (it'd be nice to use the glob patterns) and maybe it's not the best solution, but it works (at least for me) and it helped know a bit about the code base. So please have a look and let me know if you'd be interested in merging this or if you want me to make changes.

Thanks again for this useful extension!

> BTW I had to add the Nuget.config file to make `dotnet restore` work on my machine.