### PR TITLE
Obtain C# project targets from project.assets.json

### DIFF
--- a/sample/CSharpProject.AssemblyName/CSharpProject.AssemblyName.csproj
+++ b/sample/CSharpProject.AssemblyName/CSharpProject.AssemblyName.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <AssemblyName>CSharpProject.AssemblyName.Modified</AssemblyName>
+  </PropertyGroup>
+
+</Project>

--- a/sample/CSharpProject.AssemblyName/Class1.cs
+++ b/sample/CSharpProject.AssemblyName/Class1.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace CSharpProject.AssemblyName
+{
+    public class Class1
+    {
+        public static String name() {
+            return "CSharp";
+        }
+    }
+}

--- a/sample/ReferenceCSharp.AssemblyName/Library.fs
+++ b/sample/ReferenceCSharp.AssemblyName/Library.fs
@@ -1,0 +1,6 @@
+namespace ReferenceCSharp.AssemblyName
+
+module Say =
+    let hello () =
+        let csharp = CSharpProject.AssemblyName.Class1.name()
+        printfn "Hello %s" csharp

--- a/sample/ReferenceCSharp.AssemblyName/ReferenceCSharp.AssemblyName.fsproj
+++ b/sample/ReferenceCSharp.AssemblyName/ReferenceCSharp.AssemblyName.fsproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Library.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\CSharpProject.AssemblyName\CSharpProject.AssemblyName.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -8,8 +8,10 @@ dotnet restore sample/HasLocalDll/HasLocalDll.fsproj
 dotnet restore sample/FSharpKoans.Core/FSharpKoans.Core.fsproj
 dotnet restore sample/HasTests/HasTests.fsproj
 dotnet restore sample/ReferenceCSharp/ReferenceCSharp.fsproj
+dotnet restore sample/ReferenceCSharp.AssemblyName/ReferenceCSharp.AssemblyName.fsproj
 dotnet restore sample/Signature/Signature.fsproj
 dotnet build sample/CSharpProject/CSharpProject.csproj
+dotnet build sample/CSharpProject.AssemblyName/CSharpProject.AssemblyName.csproj
 dotnet build sample/SlnReferences/ReferencedProject.fsproj
 # Be sure to update .circleci/config.yml when you add sample projects
 

--- a/tests/ProjectCracker.Tests/ProjectCrackerTests.fs
+++ b/tests/ProjectCracker.Tests/ProjectCrackerTests.fs
@@ -57,6 +57,12 @@ let ``find CSharp reference``() =
     CollectionAssert.AreEquivalent(["CSharpProject.dll"], [for f in cracked.otherProjectReferences do yield f.Name])
 
 [<Test>]
+let ``find CSharp reference with modified AssemblyName``() = 
+    let fsproj = Path.Combine [|projectRoot.FullName; "sample"; "ReferenceCSharp.AssemblyName"; "ReferenceCSharp.AssemblyName.fsproj"|] |> FileInfo 
+    let cracked = ProjectCracker.crack(fsproj)
+    CollectionAssert.AreEquivalent(["CSharpProject.AssemblyName.Modified.dll"], [for f in cracked.otherProjectReferences do yield f.Name])
+
+[<Test>]
 let ``resolve template params``() = 
     let fsproj = Path.Combine [|projectRoot.FullName; "sample"; "TemplateParams"; "TemplateParams.fsproj"|] |> FileInfo 
     let cracked = ProjectCracker.crack(fsproj)


### PR DESCRIPTION
Fixes #23. For C# project references, this composes the target DLL name from `project.assets.json` when it exists. Tell me if there's anything that I've missed or that you want me to change.