### PR TITLE
Add framework preference for netcoreapp2.2

### DIFF
--- a/src/ProjectCracker/ProjectCracker.fs
+++ b/src/ProjectCracker/ProjectCracker.fs
@@ -77,6 +77,7 @@ type JsonValue with
         result
 
 let private frameworkPreference = [
+    "netcoreapp2.2", ".NETCoreApp,Version=v2.2";
     "netcoreapp2.1", ".NETCoreApp,Version=v2.1";
     "netcoreapp2.0", ".NETCoreApp,Version=v2.0";
     "netcoreapp1.1", ".NETCoreApp,Version=v1.1";


### PR DESCRIPTION
Hello,

I had an issue (`No .fsproj or .fsx file references`) when I changed my target framework to `netcoreapp2.2`.

I hope this simple fix makes it work correctly.

Thank you!