### PR TITLE
Minor adjustments to Spacemacs layer and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ Since the stock fsharp layer does not currently include LSP support, you will ne
 cp -r spacemacs/fsharp2 ~/.emacs.d/private
 ```
 
+You may also wish to suppress warnings from lsp-mode, because FSharpLanguageServer emits some notifications that lsp-mode does not support. Note that this configuration applies to all LSP languages, not just F#.
+
+```
+(add-to-list 'warning-suppress-types '(lsp-mode))
+```
+
 Finally, make sure that you have these layers enabled in your dotspacemacs-configuration-layers. You will need to remove the fsharp layer if you have it, since fsharp2 conflicts with it.
 
 - lsp 

--- a/spacemacs/fsharp2/config.el
+++ b/spacemacs/fsharp2/config.el
@@ -14,4 +14,4 @@
  "The backend to use for IDE features. Possible values are `fsac' and `lsp'")
 
 (defvar fsharp2-lsp-executable "FSharpLanguageServer"
- "The locatio nof the FSharpLanguageServer executable")
+ "The location of the FSharpLanguageServer executable")

--- a/spacemacs/fsharp2/funcs.el
+++ b/spacemacs/fsharp2/funcs.el
@@ -38,10 +38,7 @@
    (spacemacs/declare-prefix-for-mode 'fsharp-mode "mx" "executable")
    (spacemacs/declare-prefix-for-mode 'fsharp-mode "mc" "compile")
    (spacemacs/declare-prefix-for-mode 'fsharp-mode "mg" "goto")
-   (spacemacs/declare-prefix-for-mode 'fsharp-mode "mh" "hint"))
-
-  (`lsp 
-   (spacemacs/lsp-bind-keys-for-mode 'fsharp-mode))))
+   (spacemacs/declare-prefix-for-mode 'fsharp-mode "mh" "hint"))))
 
 (defun spacemacs//fsharp2-setup-company ()
  "Conditionally setup company mode"

--- a/spacemacs/fsharp2/packages.el
+++ b/spacemacs/fsharp2/packages.el
@@ -16,7 +16,6 @@
      company
      counsel-gtags 
      helm-gtags
-     flycheck-mode
   ))
 
 (defun fsharp2/init-fsharp-mode ()


### PR DESCRIPTION
- Remove flycheck-mode from fsharp2 package list. auto-complete
  initializes it for us, and fsharp2 doesn't need to do its own setup.

- The LSP layer binds keys on its own now, so Spacemacs removed the
  spacemacs/lsp-bind-keys-for-mode function. Trying to call it results
  in an error when the layer initializes.

- Add notes to documentation about suppressing lsp-mode warnings, which
  happen because lsp-mode can't process fsharp/*progress notifications