### PR TITLE
It is now valid to have a request message with no params

### DIFF
--- a/src/LSP/Parser.fs
+++ b/src/LSP/Parser.fs
@@ -103,7 +103,7 @@ let parseMessage(jsonText: string): Message =
     let raw = deserializeRawMessage jsonText
     match raw.id, raw.``params`` with
     | Some id, Some p -> RequestMessage (id, raw.method, p)
-    | Some id, None -> raise(Exception(sprintf "Request message with id %d missing params" id))
+    | Some id, None -> RequestMessage (id, raw.method, (JsonValue.Record [||]))
     | None, _ -> NotificationMessage (raw.method, raw.``params``)
 
 let parseDidChangeConfigurationParams = deserializerFactory<DidChangeConfigurationParams> readOptions


### PR DESCRIPTION
I have been experimenting with https://github.com/natebosch/vim-lsc where I ran into the issue that it sends a "shutdown" request message with no params which raises an exception in the language server.

Since the specification (https://microsoft.github.io/language-server-protocol/specification) defines params as optional:

> params?: Array<any> | object;

I made the change here and tested it with `vim-lsc` and it works :) 
As I see it this shouldn't create any issues with other clients.
