### PR TITLE
Requests with no result now yields a response with empty result

### DIFF
--- a/src/LSP/LanguageServer.fs
+++ b/src/LSP/LanguageServer.fs
@@ -218,7 +218,7 @@ let connect(serverFactory: ILanguageClient -> ILanguageServer, receive: BinaryRe
                 try 
                     match Async.RunSynchronously(task, 0, cancel.Token) with 
                     | Some(result) -> respond(send, id, result)
-                    | None -> ()
+                    | None -> respond(send, id, "{}")
                 with :? OperationCanceledException -> 
                     dprintfn "Request %d was cancelled" id
             pendingRequests.TryRemove(id) |> ignore


### PR DESCRIPTION
So similarly to https://github.com/georgewfraser/fsharp-language-server/pull/39 I also ran into that https://github.com/natebosch/vim-lsc sends a "shutdown" request, waits for a response (with timeout of 5 seconds) and then sends an "exit" to the language server. With this language server, it times out (so vim takes 5 seconds to close).

This is because the fsharp language server does not respond to requests where there is no result (like "shutdown"), the specification (https://microsoft.github.io/language-server-protocol/specification) defines:

> Every processed request must send a response back to the sender of the request.

So I made the change here and tested with `vim-lsc` and it works :)
As I see it this shouldn't create any issues with other clients.
